### PR TITLE
Add pluginList support for FindSecurityBugs

### DIFF
--- a/src/main/scala/de/johoop/findbugs4sbt/FindBugs.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/FindBugs.scala
@@ -17,12 +17,12 @@ import Keys._
 object FindBugs extends Plugin 
     with Settings with CommandLine with CommandLineExecutor {
 
-  override def findbugsTask(findbugsClasspath: Classpath, compileClasspath: Classpath, 
-      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File], 
+  override def findbugsTask(findbugsPluginList: Seq[String], findbugsClasspath: Classpath, compileClasspath: Classpath,
+      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File],
       streams: TaskStreams): Unit = {
 
     IO.withTemporaryDirectory { filterPath =>
-      val cmd = commandLine(findbugsClasspath, compileClasspath, paths, filters, filterPath, misc, streams)
+      val cmd = commandLine(findbugsPluginList, findbugsClasspath, compileClasspath, paths, filters, filterPath, misc, streams)
       streams.log.debug("FindBugs command line to execute: \"%s\"" format (cmd mkString " "))
       executeCommandLine(cmd, javaHome, streams.log)
     }

--- a/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
+++ b/src/main/scala/de/johoop/findbugs4sbt/Settings.scala
@@ -36,6 +36,7 @@ private[findbugs4sbt] trait Settings extends Plugin {
 
   val findbugs = TaskKey[Unit]("findbugs")
 
+  val findbugsPluginList = TaskKey[Seq[String]]("findbugs-plugin-list")
   val findbugsClasspath = TaskKey[Classpath]("findbugs-classpath")
   val findbugsPathSettings = TaskKey[PathSettings]("findbugs-path-settings")
   val findbugsFilterSettings = TaskKey[FilterSettings]("findbugs-filter-settings")
@@ -79,8 +80,8 @@ private[findbugs4sbt] trait Settings extends Plugin {
     * <code>None</code> by default. */ 
   val findbugsExcludeFilters = TaskKey[Option[Node]]("findbugs-exclude-filter")
 
-  protected def findbugsTask(findbugsClasspath: Classpath, compileClasspath: Classpath, 
-      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File], 
+  protected def findbugsTask(findbugsPluginList: Seq[String], findbugsClasspath: Classpath, compileClasspath: Classpath,
+      paths: PathSettings, filters: FilterSettings, misc: MiscSettings, javaHome: Option[File],
       streams: TaskStreams): Unit
 
   private val findbugsConfig = config("findbugs") hide
@@ -92,7 +93,7 @@ private[findbugs4sbt] trait Settings extends Plugin {
       "com.google.code.findbugs" % "jsr305" % "3.0.0" % "findbugs->default"
     ),
       
-    findbugs <<= (findbugsClasspath, managedClasspath in Compile, 
+    findbugs <<= (findbugsPluginList, findbugsClasspath, managedClasspath in Compile,
       findbugsPathSettings, findbugsFilterSettings, findbugsMiscSettings, javaHome, streams) map findbugsTask,
     
     findbugsPathSettings <<= (findbugsReportPath, findbugsAnalyzedPath, findbugsAuxiliaryPath) map PathSettings dependsOn (compile in Compile),
@@ -100,6 +101,7 @@ private[findbugs4sbt] trait Settings extends Plugin {
     findbugsMiscSettings <<= (findbugsReportType, findbugsPriority, findbugsOnlyAnalyze, findbugsMaxMemory, 
         findbugsAnalyzeNestedArchives, findbugsSortReportByClassNames, findbugsEffort) map MiscSettings,
 
+    findbugsPluginList := Seq(),
     findbugsClasspath := Classpaths managedJars (findbugsConfig, classpathTypes value, update value),
 
     findbugsReportType := Some(ReportType.Xml),


### PR DESCRIPTION
In order to add the FindSecurityBugs plugin to our build, we needed to have access to FindBugs's plugin mechanism. This pull requests gives this access. Here's a usage example:

```
findbugsSettings
findbugsReportPath := Some(crossTarget.value / "findbugs" / "report.html")
findbugsReportType := Some(ReportType.PlainHtml)
findbugsPluginList += s"${Path.userHome.absolutePath}/.ivy2/cache/com.h3xstream.findsecbugs/findsecbugs-plugin/jars/findsecbugs-plugin-1.4.5.jar"
findbugsIncludeFilters := Some(<FindBugsFilter>
  <Match>
    <Bug category="SECURITY"/>
  </Match>
</FindBugsFilter>)
compile <<= (compile in Compile).dependsOn(FindBugs.findbugs)
```
